### PR TITLE
Adjust quick add quantity handling and product image behavior

### DIFF
--- a/assets/css/wc-products.css
+++ b/assets/css/wc-products.css
@@ -155,11 +155,16 @@
   align-items: center; /* items-center */
   justify-content: center; /* justify-center */
   transition: opacity 300ms ease; /* transition-opacity duration-300 */
+  pointer-events: none;
 }
 
 /* Group hover overlay - group-hover:opacity-100 */
 .slidefirePro-products-wrapper .product-card:hover .product-overlay {
   opacity: 1; /* group-hover:opacity-100 */
+}
+
+.slidefirePro-products-wrapper .product-overlay .quick-add-button {
+  pointer-events: auto;
 }
 
 /* Quick Add Button - Exact Figma button structure */

--- a/assets/js/wc-products.js
+++ b/assets/js/wc-products.js
@@ -52,6 +52,7 @@
             const productId = button.data('product-id');
             const productType = button.data('product-type');
             const productUrl = button.data('product-url');
+            const quantity = parseInt(button.data('quantity'), 10) || 1;
 
             // For variable products (need option selection), go to product page
             if (productType === 'variable' && productUrl) {
@@ -85,6 +86,7 @@
                 data: {
                     action: 'slidefirePro_add_to_cart',
                     product_id: productId,
+                    quantity,
                     nonce: slideFireProAjax.nonce
                 },
                 success: (response) => {

--- a/includes/widgets/class-wc-products-widget.php
+++ b/includes/widgets/class-wc-products-widget.php
@@ -136,17 +136,31 @@ class WC_Products_Widget extends Widget_Base {
 			]
 		);
 
-		$this->add_control(
-			'quick_add_text',
-			[
-				'label' => esc_html__( 'Quick Add Text', 'slidefirePro-widgets' ),
-				'type' => Controls_Manager::TEXT,
-				'default' => esc_html__( 'Quick Add', 'slidefirePro-widgets' ),
-				'condition' => [
-					'show_quick_add_button' => 'yes',
-				],
-			]
-		);
+                $this->add_control(
+                        'quick_add_text',
+                        [
+                                'label' => esc_html__( 'Quick Add Text', 'slidefirePro-widgets' ),
+                                'type' => Controls_Manager::TEXT,
+                                'default' => esc_html__( 'Quick Add', 'slidefirePro-widgets' ),
+                                'condition' => [
+                                        'show_quick_add_button' => 'yes',
+                                ],
+                        ]
+                );
+
+                $this->add_control(
+                        'quick_add_quantity',
+                        [
+                                'label' => esc_html__( 'Quick Add Quantity', 'slidefirePro-widgets' ),
+                                'type' => Controls_Manager::NUMBER,
+                                'default' => 3,
+                                'min' => 1,
+                                'step' => 1,
+                                'condition' => [
+                                        'show_quick_add_button' => 'yes',
+                                ],
+                        ]
+                );
 
 		$this->add_control(
 			'show_load_more',
@@ -523,7 +537,9 @@ class WC_Products_Widget extends Widget_Base {
 			return '<div class="slidefirePro-no-products">' . esc_html__( 'No products found.', 'slidefirePro-widgets' ) . '</div>';
 		}
 
-		ob_start();
+                $quick_add_quantity = max( 1, (int) ( $settings['quick_add_quantity'] ?? 3 ) );
+
+                ob_start();
 		?>
 		<div class="slidefirePro-products-grid">
 			<?php
@@ -558,10 +574,11 @@ class WC_Products_Widget extends Widget_Base {
 							?>
 							<button 
 								class="quick-add-button" 
-								data-product-id="<?php echo esc_attr( get_the_ID() ); ?>"
-								data-product-type="<?php echo esc_attr( $is_variable ? 'variable' : 'simple' ); ?>"
-								data-product-url="<?php echo esc_url( get_permalink() ); ?>"
-							>
+                                                                data-product-id="<?php echo esc_attr( get_the_ID() ); ?>"
+                                                                data-product-type="<?php echo esc_attr( $is_variable ? 'variable' : 'simple' ); ?>"
+                                                                data-product-url="<?php echo esc_url( get_permalink() ); ?>"
+                                                                data-quantity="<?php echo esc_attr( $quick_add_quantity ); ?>"
+                                                        >
 								<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="cart-icon">
 									<circle cx="8" cy="21" r="1"></circle>
 									<circle cx="19" cy="21" r="1"></circle>


### PR DESCRIPTION
## Summary
- add an Elementor control to configure the quick add quantity and pass it through product card markup
- update the quick add AJAX flow to send the configured quantity and sanitize it on the server
- allow product images to open their product page by letting clicks pass through the overlay

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc161bb3c08326bb659429db7d7ae6